### PR TITLE
New reference to paper using JuliaOpt packages

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,6 +549,12 @@
           <h3>Using JuliaOpt packages</h3>
           <ul>
             <li>
+                R. Brandt and M. Bengtsson, "Fast-Convergent Distributed Coordinated Precoding for TDD Multicell MIMO Systems",
+                <i>IEEE Int. Workshop Computational Advances in Multi-Sensor Adaptive Process. (CAMSAP'15)</i>, 2015.
+                <a href="http://kth.diva-portal.org/smash/get/diva2:861877/FULLTEXT01.pdf">[PDF]</a>
+                <a href="https://github.com/rasmusbrandt/FastConvergentCoordinatedPrecoding.jl">[Code]</a>
+            </li>
+            <li>
                 D. Bertsimas and F. de Ruiter, "Duality in Two-stage Adaptive Linear Optimization: Faster Computation and Stronger Bounds". 2015. <a href="http://www.optimization-online.org/DB_FILE/2015/08/5053.pdf">[PDF]</a>
             </li>
             <li>


### PR DESCRIPTION
I've added a link to one of my papers, appearing at IEEE CAMSAP'15. In the spirit of reproducible research, there is a link to the source code as well.

The paper uses `Convex.jl` and `Mosek.jl`, which are also cited in the paper appendix.